### PR TITLE
Red-Black trees

### DIFF
--- a/src/main/scala/org/pfcoperez/dailyalgorithm/datastructures/graphs/directed/trees/binary/RedBlackTree.scala
+++ b/src/main/scala/org/pfcoperez/dailyalgorithm/datastructures/graphs/directed/trees/binary/RedBlackTree.scala
@@ -1,0 +1,95 @@
+package org.pfcoperez.dailyalgorithm.datastructures.graphs.directed.trees.binary
+
+import cats.{ Eval, Later, Now }
+import cats.Eval.{ later, now }
+
+trait RedBlackTreeOps extends BalancedBinaryTreeOps {
+
+  sealed trait RedBlackTree[+T] extends BinaryTree[T] {
+    def isRed: Boolean = false
+    def left: Eval[BinaryTree[T]]
+    def right: Eval[BinaryTree[T]]
+  }
+
+  case class BlackRoot[T](left: Eval[BinaryTree[T]], value: T, right: Eval[BinaryTree[T]]) extends RedBlackTree[T]
+
+  case class RedBlackNode[+T](left: Eval[BinaryTree[T]], value: T, override val isRed: Boolean, right: Eval[BinaryTree[T]])(
+    val parent: Eval[RedBlackTree[T]]) extends RedBlackTree[T]
+
+  object BlackEmpty extends BinaryTree[Nothing]
+
+  def leftRotation[T](node: RedBlackNode[T])(parent: Eval[RedBlackTree[T]]): Eval[BinaryTree[T]] = {
+    node.right.flatMap {
+      case prevRight: RedBlackNode[T] =>
+        lazy val replacement: Eval[RedBlackNode[T]] = later {
+          prevRight.copy(left = newLeft, right = prevRight.right)(parent)
+        }
+        lazy val newLeft = later {
+          node.copy(right = prevRight.left)(replacement)
+        }
+        updateParent(replacement)(parent)
+    }
+  }
+
+  def rightRotation[T](node: RedBlackNode[T])(parent: Eval[RedBlackTree[T]]): Eval[BinaryTree[T]] = {
+    node.left.flatMap {
+      case prevLeft: RedBlackNode[T] =>
+        lazy val replacement: Eval[RedBlackNode[T]] = later {
+          prevLeft.copy(left = prevLeft.left, right = newRight)(parent)
+        }
+        lazy val newRight = later {
+          node.copy(left = prevLeft.right)(replacement)
+        }
+        updateParent(replacement)(parent)
+    }
+  }
+
+  def updateParent[T](tree: Eval[BinaryTree[T]])(parent: Eval[RedBlackTree[T]]): Eval[BinaryTree[T]] = tree flatMap {
+    case RedBlackNode(left, v, color, right) =>
+      lazy val newTree: Eval[RedBlackNode[T]] = Later(RedBlackNode(updateParent(left)(newTree), v, color, updateParent(right)(newTree))(parent))
+      newTree
+    case other =>
+      Now(other)
+  }
+
+  override def insert[T](btree: BinaryTree[T])(v: T)(implicit order: Ordering[T]): BinaryTree[T] = {
+    import order.mkOrderingOps
+
+    def insert(btree: BinaryTree[T])(v: T, parent: Eval[RedBlackTree[T]])(implicit order: Ordering[T]): BinaryTree[T] = {
+      val unchecked = btree match {
+        case BlackEmpty =>
+          Now(RedBlackNode(Now(BlackEmpty), v, false, Now(BlackEmpty))(parent))
+        case root @ BlackRoot(left, value, right) =>
+          lazy val newRoot: Eval[RedBlackTree[T]] = later {
+            if (v <= value) BlackRoot(left.map(insert(_)(v, newRoot)), value, updateParent(right)(newRoot))
+            else BlackRoot(updateParent(left)(newRoot), value, right.map(insert(_)(v, newRoot)))
+          }
+          newRoot
+        case node @ RedBlackNode(Now(left), value, isRed, Now(right)) if left == BlackEmpty && right == BlackEmpty =>
+          lazy val replacement: Eval[RedBlackTree[T]] = later {
+            if (v <= value) RedBlackNode(later(newNode), value, isRed, now(BlackEmpty))(node.parent)
+            else RedBlackNode(now(BlackEmpty), value, isRed, later(newNode))(node.parent)
+          }
+          lazy val newNode: RedBlackNode[T] = RedBlackNode(now(BlackEmpty), v, isRed = false, now(BlackEmpty))(replacement)
+          replacement
+        case node @ RedBlackNode(left, value, _, right) =>
+          lazy val replacement: Eval[RedBlackNode[T]] = later {
+            if (v <= value) node.copy(left = left.map(insert(_)(v, replacement)))(node.parent)
+            else node.copy(right = right.map(insert(_)(v, replacement)))(node.parent)
+          }
+          updateParent(replacement)(parent)
+      }
+      unchecked.value //TODO: Check balance
+    }
+
+    btree match {
+      case btree: RedBlackNode[T] =>
+        insert(btree)(v, btree.parent)
+      case _: BlackRoot[T] =>
+        insert(btree)(v, Later(???))
+    }
+  }
+
+}
+
+object RedBlackTree extends RedBlackTreeOps

--- a/src/main/scala/org/pfcoperez/dailyalgorithm/datastructures/graphs/directed/trees/binary/RedBlackTree.scala
+++ b/src/main/scala/org/pfcoperez/dailyalgorithm/datastructures/graphs/directed/trees/binary/RedBlackTree.scala
@@ -18,6 +18,36 @@ trait RedBlackTreeOps extends BalancedBinaryTreeOps {
 
   object BlackEmpty extends BinaryTree[Nothing]
 
+  /*
+  private def insertFixUp[T](rbtree: RedBlackTree[T], current: RedBlackTree[T])(implicit vOrd: Ordering[T]): RedBlackTree[T] = {
+    import vOrd.mkOrderingOps
+
+    def setColor(rbtree: RedBlackTree[T], node: RedBlackNode[T], toRed: Boolean, prev: => RedBlackTree[T]): RedBlackTree[T] = rbtree match {
+      case BlackRoot(left: RedBlackTree[T], value, right: RedBlackTree[T]) =>
+        lazy val updatedNode: BlackRoot[T] =  if(node.value <= value) BlackRoot(setColor(left, node, toRed, updatedNode), value, right)
+        else BlackRoot(left, value, setColor(right, node, toRed, updatedNode))
+        updatedNode
+      case currentNode @ RedBlackNode(left, value, isRed, right) =>
+        if(currentNode eq node) currentNode.copy(isRed = toRed)(parent = )
+        ???
+    }
+
+    current match {
+      case node: RedBlackNode[T] if node.parent.isRed =>
+        node.parent match {
+          case parent: RedBlackNode[T] if(parent.parent.left eq parent) =>
+            parent.parent.right match {
+              case RedBlackNode(_, _, true, _) =>
+                ???
+            }
+            ???
+          case _ =>
+            ???
+        }
+      case _ => rbtree
+    }
+  }*/
+
   def leftRotation[T](node: RedBlackNode[T])(parent: Eval[RedBlackTree[T]]): Eval[BinaryTree[T]] = {
     node.right.flatMap {
       case prevRight: RedBlackNode[T] =>

--- a/src/test/scala/org/pfcoperez/dailyalgorithm/datastructures/graphs/directed/trees/binary/RedBlackTreeSpec.scala
+++ b/src/test/scala/org/pfcoperez/dailyalgorithm/datastructures/graphs/directed/trees/binary/RedBlackTreeSpec.scala
@@ -59,19 +59,35 @@ class RedBlackTreeSpec extends FlatSpec with Matchers with Inside {
     }
   }
 
+  def inOrderTraverse[T](binaryTree: BinaryTree[T]): List[T] = binaryTree match {
+    case RedBlackNode(left, v, _, right) =>
+      inOrderTraverse(left.value) ::: v +: inOrderTraverse(right.value)
+    case _ => Nil
+  }
+
+  def preOrderTraverse[T](binaryTree: BinaryTree[T]): List[T] = binaryTree match {
+    case RedBlackNode(left, v, _, right) =>
+      v +: preOrderTraverse(left.value) ::: preOrderTraverse(right.value)
+    case _ => Nil
+  }
+
   it should "preserve parenthood relations after rotations" in {
 
-
     val tree = ((BlackRoot(Now(BlackEmpty), -1, Now(BlackEmpty)): BinaryTree[Int]) /: List(2, 1, 0, 4, 3, 5, 6))(insert(_)(_))
-
     val target = tree.asInstanceOf[BlackRoot[Int]].right.value.asInstanceOf[RedBlackNode[Int]]
 
-    val res = leftRotation(target)(Later(RedBlackNode(Later(???), -10, false, Later(???))(Later(???)))).value.asInstanceOf[RedBlackNode[Int]]
+    val leftRotated = leftRotation(target)(Later(RedBlackNode(Later(???), -10, false, Later(???))(Later(???)))).value.asInstanceOf[RedBlackNode[Int]]
+    val rightRotatedAfterLeftRotated = rightRotation(leftRotated)(Later(RedBlackNode(Later(???), -10, false, Later(???))(Later(???)))).value
 
-    val counterRes = rightRotation(res)(Later(RedBlackNode(Later(???), -10, false, Later(???))(Later(???)))).value
+    withClue("preserve binary trees condition") {
+      inOrderTraverse(target) shouldBe inOrderTraverse(leftRotated)
+      inOrderTraverse(leftRotated) shouldBe inOrderTraverse(rightRotatedAfterLeftRotated)
+    }
 
-    // (res -> counterRes) TODO: Finish test
-
+    withClue("right rotation after left rotation should act as identity") {
+      preOrderTraverse(target) shouldBe preOrderTraverse(rightRotatedAfterLeftRotated)
+      preOrderTraverse(target) should not be preOrderTraverse(leftRotated)
+    }
   }
 
 }

--- a/src/test/scala/org/pfcoperez/dailyalgorithm/datastructures/graphs/directed/trees/binary/RedBlackTreeSpec.scala
+++ b/src/test/scala/org/pfcoperez/dailyalgorithm/datastructures/graphs/directed/trees/binary/RedBlackTreeSpec.scala
@@ -1,0 +1,77 @@
+package org.pfcoperez.dailyalgorithm.datastructures.graphs.directed.trees.binary
+
+import cats.{Later, Now}
+import org.scalatest.{FlatSpec, Inside, Matchers}
+
+class RedBlackTreeSpec extends FlatSpec with Matchers with Inside {
+
+  import RedBlackTree._
+
+  "RedBlackTree" should "grow preserving parenthood relations" in {
+    val grownTree = ((BlackRoot(Now(BlackEmpty), -1, Now(BlackEmpty)): BinaryTree[Int]) /: List(2, 1, 0, 4, 3, 5, 6))(
+      insert(_)(_)
+    )
+
+    inside(grownTree) {
+      case BlackRoot(_, -1, right) =>
+        inside(right.value) {
+          case RedBlackNode(left2, 2, _, right2) =>
+            inside(left2.value) {
+              case RedBlackNode(left1, 1, _, right1) =>
+                inside(left1.value) {
+                  case leaf @ RedBlackNode(_, 0, _, _) =>
+                    val goneAndBack = for {
+                      up1 <- leaf.parent
+                      up2 <- up1.asInstanceOf[RedBlackNode[Int]].parent
+                      down1 <- up2.left
+                      down0 <- down1.asInstanceOf[RedBlackNode[Int]].left
+                    } yield down0
+                    val RedBlackNode(_, zero, _, _) = goneAndBack.value
+                    zero shouldBe 0
+                }
+            }
+            inside(right2.value) {
+              case RedBlackNode(left4, 4, _, right4) =>
+                inside(left4.value) {
+                  case three @ RedBlackNode(_, 3, _, _) =>
+                    val goneAndBack = for {
+                      up4 <- three.parent
+                      up2 <- up4.asInstanceOf[RedBlackNode[Int]].parent
+                      down4 <- up2.right
+                      down3 <- down4.asInstanceOf[RedBlackNode[Int]].left
+                    } yield down3
+                    val RedBlackNode(_, down3, _, _) = goneAndBack.value
+                    down3 shouldBe 3
+                }
+                inside(right4.value) {
+                  case five @ RedBlackNode(_, 5, _, _) =>
+                    val goneAndBack = for {
+                      up4 <- five.parent
+                      up2 <- up4.asInstanceOf[RedBlackNode[Int]].parent
+                      down4 <- up2.right
+                      down5 <- down4.asInstanceOf[RedBlackNode[Int]].right
+                    } yield down5
+                    val RedBlackNode(_, down5, _, _) = goneAndBack.value
+                    down5 shouldBe 5
+                }
+            }
+        }
+    }
+  }
+
+  it should "preserve parenthood relations after rotations" in {
+
+
+    val tree = ((BlackRoot(Now(BlackEmpty), -1, Now(BlackEmpty)): BinaryTree[Int]) /: List(2, 1, 0, 4, 3, 5, 6))(insert(_)(_))
+
+    val target = tree.asInstanceOf[BlackRoot[Int]].right.value.asInstanceOf[RedBlackNode[Int]]
+
+    val res = leftRotation(target)(Later(RedBlackNode(Later(???), -10, false, Later(???))(Later(???)))).value.asInstanceOf[RedBlackNode[Int]]
+
+    val counterRes = rightRotation(res)(Later(RedBlackNode(Later(???), -10, false, Later(???))(Later(???)))).value
+
+    // (res -> counterRes) TODO: Finish test
+
+  }
+
+}


### PR DESCRIPTION
Resolves https://github.com/pfcoperez/algorithmaday/issues/15

## Description

This PR adds completely transparent RedBlack :red_circle: :black_circle:  trees implementation based on tying-the-not via lazy evaluation and [Typelevel's Cats](https://typelevel.org/cats/) [`Eval  monad`](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/Eval.scala).

### Please, don't forget to include:

- [ ] Completed implementation.
- [ ] Time complexity bounds.
- [ ] Unit tests / Examples of use
- [ ] Your Twitter handle, LinkedIn profile, ... so you get the credit!

### Optionally, you might like to add:

- [ ] Diagrams.
- [ ] Memory complexity bounds.
- [ ] Performance tests.
- [ ] A context on which your contribution might be used.
